### PR TITLE
Bump the minimum supported version to 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 60
 
     steps:

--- a/Tuist/ProjectDescriptionHelpers/DeploymentTarget.swift
+++ b/Tuist/ProjectDescriptionHelpers/DeploymentTarget.swift
@@ -7,7 +7,7 @@ import ProjectDescription
 extension DeploymentTarget {
 
     public static let app: Self = .macOS(
-        targetVersion: "12.0"
+        targetVersion: "13.0"
     )
 
 }


### PR DESCRIPTION
### Changed

- Bump the minimum supported version to 13

### Checklist ✅

- [x] The code has been linted using the command `make lint`.
- [x] Unit tests have been written to ensure major functionality is not broken.
- [x] An issue has been created for this task/feature.
