### PR TITLE
Fix the example view name in the module template

### DIFF
--- a/Tuist/Templates/module/module.swift
+++ b/Tuist/Templates/module/module.swift
@@ -18,7 +18,7 @@ let template = Template(
         .file(path: "Projects/\(name)/Tests/\(name)Tests.swift", templatePath: "tests.stencil"),
         .file(path: "Projects/\(name)/Resources/Assets.xcassets/Contents.json", templatePath: "contents_json.stencil"),
         .file(path: "Projects/\(name)/Example/Sources/\(name)ExampleApp.swift", templatePath: "example_app.stencil"),
-        .file(path: "Projects/\(name)/Example/Sources/ContentView.swift", templatePath: "example_view.stencil"),
+        .file(path: "Projects/\(name)/Example/Sources/\(name)ExampleView.swift", templatePath: "example_view.stencil"),
         .file(path: "Projects/\(name)/Example/Resources/Assets.xcassets/Contents.json", templatePath: "contents_json.stencil"),
     ]
 )


### PR DESCRIPTION
### Fixed

- example view file name
  - ContentView -> {{ moduleName }}ExampleView

### Checklist ✅

- [ ] The code has been linted using the command `make lint`.
- [ ] Unit tests have been written to ensure major functionality is not broken.
- [ ] An issue has been created for this task/feature.
