### PR TITLE
Remove default resources path for static frameworks

### DIFF
--- a/Projects/Common/CoralKit/Project.swift
+++ b/Projects/Common/CoralKit/Project.swift
@@ -5,7 +5,7 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-let project = Project.dynamicFramework(
+let project = Project.dynamic(
     name: "CoralKit",
     packages: [],
     baseSettings: [:],

--- a/Projects/Common/CoralUI/Project.swift
+++ b/Projects/Common/CoralUI/Project.swift
@@ -5,7 +5,7 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-let project = Project.dynamicFramework(
+let project = Project.dynamic(
     name: "CoralUI",
     packages: [],
     baseSettings: [:],

--- a/Projects/Features/CaseConverter/Project.swift
+++ b/Projects/Features/CaseConverter/Project.swift
@@ -5,7 +5,7 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-let project = Project.staticFramework(
+let project = Project.static(
     name: "CaseConverter",
     packages: [],
     baseSettings: [:],

--- a/Projects/Features/CaseConverter/Resources/Assets.xcassets/Contents.json
+++ b/Projects/Features/CaseConverter/Resources/Assets.xcassets/Contents.json
@@ -1,6 +1,0 @@
-{
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
-}

--- a/Projects/Features/ColorConverter/Project.swift
+++ b/Projects/Features/ColorConverter/Project.swift
@@ -5,7 +5,7 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-let project = Project.staticFramework(
+let project = Project.static(
     name: "ColorConverter",
     packages: [],
     baseSettings: [:],

--- a/Projects/Features/ColorConverter/Resources/Assets.xcassets/Contents.json
+++ b/Projects/Features/ColorConverter/Resources/Assets.xcassets/Contents.json
@@ -1,6 +1,0 @@
-{
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
-}

--- a/Tuist/ProjectDescriptionHelpers/Project.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project.swift
@@ -44,10 +44,12 @@ public extension Project {
         )
     }
 
-    static func dynamicFramework(
+    static func dynamic(
         name: String,
         packages: [Package],
         baseSettings: SettingsDictionary,
+        sources: SourceFilesList? = ["Sources/**"],
+        resources: ResourceFileElements? = ["Resources/**"],
         dependencies: [TargetDependency],
         includeExample: Bool
     ) -> Self {
@@ -60,15 +62,19 @@ public extension Project {
                 defaultSettings: .recommended
             ),
             product: .framework,
+            sources: sources,
+            resources: resources,
             dependencies: dependencies,
             includeExample: includeExample
         )
     }
 
-    static func staticFramework(
+    static func `static`(
         name: String,
         packages: [Package],
         baseSettings: SettingsDictionary,
+        sources: SourceFilesList? = ["Sources/**"],
+        resources: ResourceFileElements? = nil,
         dependencies: [TargetDependency],
         includeExample: Bool
     ) -> Self {
@@ -80,7 +86,9 @@ public extension Project {
                 configurations: .moduleConfiguration(name),
                 defaultSettings: .recommended
             ),
-            product: .staticFramework,
+            product: resources == nil ? .staticLibrary : .staticFramework,
+            sources: sources,
+            resources: resources,
             dependencies: dependencies,
             includeExample: includeExample
         )
@@ -91,6 +99,8 @@ public extension Project {
         packages: [Package],
         settings: Settings?,
         product: Product,
+        sources: SourceFilesList?,
+        resources: ResourceFileElements?,
         dependencies: [TargetDependency],
         includeExample: Bool
     ) -> Self {
@@ -103,6 +113,8 @@ public extension Project {
             targets: .moduleTargets(
                 name: name,
                 product: product,
+                sources: sources,
+                resources: resources,
                 dependencies: dependencies,
                 includeExample: includeExample
             ),

--- a/Tuist/ProjectDescriptionHelpers/Target.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target.swift
@@ -26,6 +26,8 @@ extension Array where Element == Target {
     static func moduleTargets(
         name: String,
         product: Product,
+        sources: SourceFilesList?,
+        resources: ResourceFileElements?,
         dependencies: [TargetDependency],
         includeExample: Bool
     ) -> [Target] {
@@ -33,6 +35,8 @@ extension Array where Element == Target {
             .module(
                 name: name,
                 product: product,
+                sources: sources,
+                resources: resources,
                 dependencies: dependencies
             ),
             .interface(name: name),
@@ -118,6 +122,8 @@ extension Target {
     fileprivate static func module(
         name: String,
         product: Product,
+        sources: SourceFilesList?,
+        resources: ResourceFileElements?,
         dependencies: [TargetDependency]
     ) -> Self {
         Target(
@@ -128,8 +134,8 @@ extension Target {
             bundleId: Coral.bundleId(name),
             deploymentTarget: .app,
             infoPlist: .default,
-            sources: ["Sources/**"],
-            resources: ["Resources/**"],
+            sources: sources,
+            resources: resources,
             copyFiles: nil,
             headers: nil,
             entitlements: nil,


### PR DESCRIPTION
### Changed

- Remove default resources path for static frameworks
  - Remove resources for ColorConverter and CaseConverter

### Checklist ✅

- [x] The code has been linted using the command `make lint`.
- [x] Unit tests have been written to ensure major functionality is not broken.
