### PR TITLE
Changed the conversion method and add CaseConvertTypes

### DIFF
--- a/Projects/Features/CaseConverter/Sources/Screens/CaseConverter/CaseConverterScreen.swift
+++ b/Projects/Features/CaseConverter/Sources/Screens/CaseConverter/CaseConverterScreen.swift
@@ -16,7 +16,7 @@ public struct CaseConverterScreen: View {
     }
 
     public var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 40) {
             menuStack
 
             HStack(alignment: .top, spacing: 16) {
@@ -78,15 +78,21 @@ public struct CaseConverterScreen: View {
     }
 
     var outputText: some View {
-        Text(way.state.output)
-            .textSelection(.enabled)
-            .font(.body)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            .foregroundColor(Color.white)
-            .padding(24)
-            .background(Color.black.cornerRadius(16))
-            .multilineTextAlignment(.leading)
-            .overlay(copyButton, alignment: .bottomTrailing)
+        ScrollView(.vertical) {
+            VStack(spacing: .zero) {
+                Text(way.state.output)
+                    .textSelection(.enabled)
+                    .font(.body)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .foregroundColor(Color.white)
+                    .multilineTextAlignment(.leading)
+
+                Spacer()
+            }
+        }
+        .padding(24)
+        .background(Color.black.cornerRadius(16))
+        .overlay(copyButton, alignment: .bottomTrailing)
     }
 
     var copyButton: some View {

--- a/Projects/Features/CaseConverter/Sources/Utils/CaseConverterType.swift
+++ b/Projects/Features/CaseConverter/Sources/Utils/CaseConverterType.swift
@@ -27,6 +27,12 @@ public enum CaseConverterType: Equatable, Identifiable, CaseIterable {
     }
 
     func convert(_ input: String) -> String {
+        input.split(whereSeparator: \.isNewline)
+            .map { convertLine(String($0)) }
+            .joined(separator: "\n")
+    }
+
+    func convertLine(_ input: String) -> String {
         switch self {
         case .snake:
             return input.snakeCased()

--- a/Projects/Features/CaseConverter/Tests/Utils/CaseConverterTypeTests.swift
+++ b/Projects/Features/CaseConverter/Tests/Utils/CaseConverterTypeTests.swift
@@ -50,6 +50,38 @@ final class CaseConverterTypeTests: XCTestCase {
             let result = CaseConverterType.camel.convert(input)
             XCTAssertEqual(result, "tokenTokenTokenToken")
         }
+
+        do {
+            let input =
+            """
+            camelCase
+            onMultiline
+            """
+            let result = CaseConverterType.camel.convert(input)
+            XCTAssertEqual(
+                result,
+                """
+                camelCase
+                onMultiline
+                """
+            )
+        }
+
+        do {
+            let input =
+            """
+            camel_case
+            on_multiline
+            """
+            let result = CaseConverterType.camel.convert(input)
+            XCTAssertEqual(
+                result,
+                """
+                camelCase
+                onMultiline
+                """
+            )
+        }
     }
 
     func testConvertToSnake() {
@@ -93,6 +125,22 @@ final class CaseConverterTypeTests: XCTestCase {
             let input = "tokenToken_token-token"
             let result = CaseConverterType.snake.convert(input)
             XCTAssertEqual(result, "token_token_token_token")
+        }
+
+        do {
+            let input =
+            """
+            camelCase
+            onMultiline
+            """
+            let result = CaseConverterType.snake.convert(input)
+            XCTAssertEqual(
+                result,
+                """
+                camel_case
+                on_multiline
+                """
+            )
         }
     }
 

--- a/Projects/Features/CaseConverter/Tests/Utils/CaseConverterTypeTests.swift
+++ b/Projects/Features/CaseConverter/Tests/Utils/CaseConverterTypeTests.swift
@@ -8,23 +8,11 @@ import XCTest
 
 final class CaseConverterTypeTests: XCTestCase {
 
-    func testSnakeToCamel() {
+    func testConvertToCamel() {
         do {
-            let input = "snake_to_camel"
+            let input = "abc"
             let result = CaseConverterType.camel.convert(input)
-            XCTAssertEqual(result, "snakeToCamel")
-        }
-
-        do {
-            let input = "snake_t_camel"
-            let result = CaseConverterType.camel.convert(input)
-            XCTAssertEqual(result, "snakeTCamel")
-        }
-
-        do {
-            let input = "snake"
-            let result = CaseConverterType.camel.convert(input)
-            XCTAssertEqual(result, "snake")
+            XCTAssertEqual(result, "abc")
         }
 
         do {
@@ -32,25 +20,43 @@ final class CaseConverterTypeTests: XCTestCase {
             let result = CaseConverterType.camel.convert(input)
             XCTAssertEqual(result, "alreadyCamelCase")
         }
+
+        do {
+            let input = "this_is_snake_case"
+            let result = CaseConverterType.camel.convert(input)
+            XCTAssertEqual(result, "thisIsSnakeCase")
+        }
+
+        do {
+            let input = "CONSTANT_CASE"
+            let result = CaseConverterType.camel.convert(input)
+            XCTAssertEqual(result, "constantCase")
+        }
+
+        do {
+            let input = "parameter-case"
+            let result = CaseConverterType.camel.convert(input)
+            XCTAssertEqual(result, "parameterCase")
+        }
+
+        do {
+            let input = "PascalCase"
+            let result = CaseConverterType.camel.convert(input)
+            XCTAssertEqual(result, "pascalCase")
+        }
+
+        do {
+            let input = "tokenToken_token-token"
+            let result = CaseConverterType.camel.convert(input)
+            XCTAssertEqual(result, "tokenTokenTokenToken")
+        }
     }
 
-    func testCamelToSnake() {
+    func testConvertToSnake() {
         do {
-            let input = "camelToSnake"
+            let input = "abc"
             let result = CaseConverterType.snake.convert(input)
-            XCTAssertEqual(result, "camel_to_snake")
-        }
-
-        do {
-            let input = "camelToS"
-            let result = CaseConverterType.snake.convert(input)
-            XCTAssertEqual(result, "camel_to_s")
-        }
-
-        do {
-            let input = "camel"
-            let result = CaseConverterType.snake.convert(input)
-            XCTAssertEqual(result, "camel")
+            XCTAssertEqual(result, "abc")
         }
 
         do {
@@ -58,6 +64,167 @@ final class CaseConverterTypeTests: XCTestCase {
             let result = CaseConverterType.snake.convert(input)
             XCTAssertEqual(result, "already_snake_case")
         }
+
+        do {
+            let input = "camelToSnake"
+            let result = CaseConverterType.snake.convert(input)
+            XCTAssertEqual(result, "camel_to_snake")
+        }
+
+        do {
+            let input = "CONSTANT_CASE"
+            let result = CaseConverterType.snake.convert(input)
+            XCTAssertEqual(result, "constant_case")
+        }
+
+        do {
+            let input = "parameter-case"
+            let result = CaseConverterType.snake.convert(input)
+            XCTAssertEqual(result, "parameter_case")
+        }
+
+        do {
+            let input = "PascalCase"
+            let result = CaseConverterType.snake.convert(input)
+            XCTAssertEqual(result, "pascal_case")
+        }
+
+        do {
+            let input = "tokenToken_token-token"
+            let result = CaseConverterType.snake.convert(input)
+            XCTAssertEqual(result, "token_token_token_token")
+        }
     }
 
+    func testConvertToParameter() {
+        do {
+            let input = "abc"
+            let result = CaseConverterType.parameter.convert(input)
+            XCTAssertEqual(result, "abc")
+        }
+
+        do {
+            let input = "already-parameter-case"
+            let result = CaseConverterType.parameter.convert(input)
+            XCTAssertEqual(result, "already-parameter-case")
+        }
+
+        do {
+            let input = "camelToParameter"
+            let result = CaseConverterType.parameter.convert(input)
+            XCTAssertEqual(result, "camel-to-parameter")
+        }
+
+        do {
+            let input = "CONSTANT_CASE"
+            let result = CaseConverterType.parameter.convert(input)
+            XCTAssertEqual(result, "constant-case")
+        }
+
+        do {
+            let input = "snake_case"
+            let result = CaseConverterType.parameter.convert(input)
+            XCTAssertEqual(result, "snake-case")
+        }
+
+        do {
+            let input = "PascalCase"
+            let result = CaseConverterType.parameter.convert(input)
+            XCTAssertEqual(result, "pascal-case")
+        }
+
+        do {
+            let input = "tokenToken_token-token"
+            let result = CaseConverterType.parameter.convert(input)
+            XCTAssertEqual(result, "token-token-token-token")
+        }
+    }
+
+    func testConvertToConstant() {
+        do {
+            let input = "abc"
+            let result = CaseConverterType.constant.convert(input)
+            XCTAssertEqual(result, "ABC")
+        }
+
+        do {
+            let input = "ALREADY_CONSTANT_CASE"
+            let result = CaseConverterType.constant.convert(input)
+            XCTAssertEqual(result, "ALREADY_CONSTANT_CASE")
+        }
+
+        do {
+            let input = "camelToConstant"
+            let result = CaseConverterType.constant.convert(input)
+            XCTAssertEqual(result, "CAMEL_TO_CONSTANT")
+        }
+
+        do {
+            let input = "snake_case"
+            let result = CaseConverterType.constant.convert(input)
+            XCTAssertEqual(result, "SNAKE_CASE")
+        }
+
+        do {
+            let input = "parameter-case"
+            let result = CaseConverterType.constant.convert(input)
+            XCTAssertEqual(result, "PARAMETER_CASE")
+        }
+
+        do {
+            let input = "PascalCase"
+            let result = CaseConverterType.constant.convert(input)
+            XCTAssertEqual(result, "PASCAL_CASE")
+        }
+
+        do {
+            let input = "tokenToken_token-token"
+            let result = CaseConverterType.constant.convert(input)
+            XCTAssertEqual(result, "TOKEN_TOKEN_TOKEN_TOKEN")
+        }
+    }
+
+    func testConvertToPascal() {
+        do {
+            let input = "abc"
+            let result = CaseConverterType.pascal.convert(input)
+            XCTAssertEqual(result, "Abc")
+        }
+
+        do {
+            let input = "AlreadyPascalCase"
+            let result = CaseConverterType.pascal.convert(input)
+            XCTAssertEqual(result, "AlreadyPascalCase")
+        }
+
+        do {
+            let input = "camelToPascal"
+            let result = CaseConverterType.pascal.convert(input)
+            XCTAssertEqual(result, "CamelToPascal")
+        }
+
+        do {
+            let input = "snake_case"
+            let result = CaseConverterType.pascal.convert(input)
+            XCTAssertEqual(result, "SnakeCase")
+        }
+
+        do {
+            let input = "parameter-case"
+            let result = CaseConverterType.pascal.convert(input)
+            XCTAssertEqual(result, "ParameterCase")
+        }
+
+        do {
+            let input = "CONSTANT_CASE"
+            let result = CaseConverterType.pascal.convert(input)
+            XCTAssertEqual(result, "ConstantCase")
+        }
+
+        do {
+            let input = "tokenToken_token-token"
+            let result = CaseConverterType.pascal.convert(input)
+            XCTAssertEqual(result, "TokenTokenTokenToken")
+        }
+    }
 }


### PR DESCRIPTION
### Added
- added pascal, constant, parameter conversion types.

### Changed
- the string conversion method was changed to apply each case style after tokenization.

### Fixed
- output textView wrapped in scroll view.

### Checklist ✅

- [x] The code has been linted using the command `make lint`.
- [x] Unit tests have been written to ensure major functionality is not broken.
