### PR TITLE
Add a ColorType protocol which has source color

### DIFF
--- a/Projects/Features/ColorConverter/Interface/ColorType.swift
+++ b/Projects/Features/ColorConverter/Interface/ColorType.swift
@@ -1,0 +1,13 @@
+// The MIT License (MIT)
+//
+// https://github.com/DevYeom/Coral
+
+import Foundation
+
+public protocol ColorType {
+
+    associatedtype C: ColorConvertible
+
+    var sourceColor: C { get }
+
+}

--- a/Projects/Features/ColorConverter/Sources/Extensions/CMYKColor+ColorType.swift
+++ b/Projects/Features/ColorConverter/Sources/Extensions/CMYKColor+ColorType.swift
@@ -5,10 +5,9 @@
 import ColorConverterInterface
 import Foundation
 
-extension CMYKColor: ColorConvertible {
+extension CMYKColor: ColorType {
 
-    /// https://github.com/bennyguitar/Colours
-    public var toRGB: RGBColor {
+    public var sourceColor: RGBColor {
         let transform: (Double) -> Double = { value in
             1.0 - (value * (1.0 - key) + key)
         }
@@ -17,18 +16,6 @@ extension CMYKColor: ColorConvertible {
             green: transform(magenta),
             blue: transform(yellow)
         )
-    }
-
-    public var toHex: HexColor {
-        toRGB.toHex
-    }
-
-    public var toCMYK: CMYKColor {
-        self
-    }
-
-    public var toHSB: HSBColor {
-        toRGB.toHSB
     }
 
 }

--- a/Projects/Features/ColorConverter/Sources/Extensions/CMYKColor+Validatable.swift
+++ b/Projects/Features/ColorConverter/Sources/Extensions/CMYKColor+Validatable.swift
@@ -12,7 +12,7 @@ extension CMYKColor: Validatable {
             && Double.zero ... 1.0 ~= magenta
             && Double.zero ... 1.0 ~= yellow
             && Double.zero ... 1.0 ~= key
-            && toRGB.isValid
+            && sourceColor.isValid
     }
 
 }

--- a/Projects/Features/ColorConverter/Sources/Extensions/HSBColor+ColorType.swift
+++ b/Projects/Features/ColorConverter/Sources/Extensions/HSBColor+ColorType.swift
@@ -6,9 +6,9 @@ import AppKit
 import ColorConverterInterface
 import Foundation
 
-extension HSBColor: ColorConvertible {
+extension HSBColor: ColorType {
 
-    public var toRGB: ColorConverterInterface.RGBColor {
+    public var sourceColor: ColorConverterInterface.RGBColor {
         let nsColor = NSColor(
             hue: hue,
             saturation: saturation,
@@ -25,18 +25,6 @@ extension HSBColor: ColorConvertible {
             green: green,
             blue: blue
         )
-    }
-
-    public var toHex: HexColor {
-        toRGB.toHex
-    }
-
-    public var toCMYK: CMYKColor {
-        toRGB.toCMYK
-    }
-
-    public var toHSB: HSBColor {
-        self
     }
 
 }

--- a/Projects/Features/ColorConverter/Sources/Extensions/HSBColor+Validatable.swift
+++ b/Projects/Features/ColorConverter/Sources/Extensions/HSBColor+Validatable.swift
@@ -11,7 +11,7 @@ extension HSBColor: Validatable {
         Double.zero ... 1.0 ~= hue
             && Double.zero ... 1.0 ~= saturation
             && Double.zero ... 1.0 ~= brightness
-            && toRGB.isValid
+            && sourceColor.isValid
     }
 
 }

--- a/Projects/Features/ColorConverter/Sources/Extensions/HexColor+ColorType.swift
+++ b/Projects/Features/ColorConverter/Sources/Extensions/HexColor+ColorType.swift
@@ -5,10 +5,10 @@
 import ColorConverterInterface
 import Foundation
 
-extension HexColor: ColorConvertible {
+extension HexColor: ColorType {
 
     /// https://www.hackingwithswift.com/example-code/uicolor/how-to-convert-a-hex-color-to-a-uicolor
-    public var toRGB: RGBColor {
+    public var sourceColor: RGBColor {
         let startIndex = value.index(value.startIndex, offsetBy: 1)
         let hexColor = String(value[startIndex...])
         let scanner = Scanner(string: hexColor)
@@ -24,18 +24,6 @@ extension HexColor: ColorConvertible {
         }
         assertionFailure("The input for hex to rgb conversion is incorrect: \(value)")
         return .black
-    }
-
-    public var toHex: HexColor {
-        self
-    }
-
-    public var toCMYK: CMYKColor {
-        toRGB.toCMYK
-    }
-
-    public var toHSB: HSBColor {
-        toRGB.toHSB
     }
 
 }

--- a/Projects/Features/ColorConverter/Sources/Extensions/RGBColor+ColorConvertible.swift
+++ b/Projects/Features/ColorConverter/Sources/Extensions/RGBColor+ColorConvertible.swift
@@ -6,18 +6,6 @@ import AppKit
 import ColorConverterInterface
 import Foundation
 
-extension ColorConverterInterface.RGBColor {
-
-    static var black: ColorConverterInterface.RGBColor {
-        RGBColor(
-            red: .zero,
-            green: .zero,
-            blue: .zero
-        )
-    }
-
-}
-
 extension ColorConverterInterface.RGBColor: ColorConvertible {
 
     public var toRGB: ColorConverterInterface.RGBColor {

--- a/Projects/Features/ColorConverter/Sources/Extensions/RGBColor+ColorType.swift
+++ b/Projects/Features/ColorConverter/Sources/Extensions/RGBColor+ColorType.swift
@@ -1,0 +1,26 @@
+// The MIT License (MIT)
+//
+// https://github.com/DevYeom/Coral
+
+import ColorConverterInterface
+import Foundation
+
+extension RGBColor: ColorType {
+
+    public var sourceColor: RGBColor {
+        self
+    }
+
+}
+
+extension RGBColor {
+
+    static var black: ColorConverterInterface.RGBColor {
+        RGBColor(
+            red: .zero,
+            green: .zero,
+            blue: .zero
+        )
+    }
+
+}

--- a/Projects/Features/ColorConverter/Tests/ColorConverterTests.swift
+++ b/Projects/Features/ColorConverter/Tests/ColorConverterTests.swift
@@ -101,28 +101,28 @@ final class ColorConverterTests: XCTestCase {
     func test_hex_to_rgb() {
         do {
             let hex = HexColor(value: "#000000")
-            let rgb = hex.toRGB
+            let rgb = hex.sourceColor
             let expected = RGBColor(red: .zero, green: .zero, blue: .zero)
             XCTAssertEqual(rgb, expected)
         }
 
         do {
             let hex = HexColor(value: "#FFFFFF")
-            let rgb = hex.toRGB
+            let rgb = hex.sourceColor
             let expected = RGBColor(red: 1.0, green: 1.0, blue: 1.0)
             XCTAssertEqual(rgb, expected)
         }
 
         do {
             let hex = HexColor(value: "#7A7EE6")
-            let rgb = hex.toRGB
+            let rgb = hex.sourceColor
             let expected = RGBColor(red: 122.0 / 255.0, green: 126.0 / 255.0, blue: 230.0 / 255.0)
             XCTAssertEqual(rgb, expected)
         }
 
         do {
             let hex = HexColor(value: "#755446")
-            let rgb = hex.toRGB
+            let rgb = hex.sourceColor
             let expected = RGBColor(red: 117.0 / 255.0, green: 84.0 / 255.0, blue: 70.0 / 255.0)
             XCTAssertEqual(rgb, expected)
         }
@@ -131,28 +131,28 @@ final class ColorConverterTests: XCTestCase {
     func test_cmyk_to_rgb() {
         do {
             let cmyk = CMYKColor(cyan: .zero, magenta: .zero, yellow: .zero, key: 1.0)
-            let rgb = cmyk.toRGB
+            let rgb = cmyk.sourceColor
             let expected = RGBColor(red: .zero, green: .zero, blue: .zero)
             XCTAssertEqual(rgb, expected)
         }
 
         do {
             let cmyk = CMYKColor(cyan: .zero, magenta: .zero, yellow: .zero, key: .zero)
-            let rgb = cmyk.toRGB
+            let rgb = cmyk.sourceColor
             let expected = RGBColor(red: 1.0, green: 1.0, blue: 1.0)
             XCTAssertEqual(rgb, expected)
         }
 
         do {
             let cmyk = CMYKColor(cyan: 0.47, magenta: 0.45, yellow: .zero, key: 0.10)
-            let rgb = cmyk.toRGB
+            let rgb = cmyk.sourceColor
             let expected = RGBColor(red: 122.0 / 255.0, green: 126.0 / 255.0, blue: 230.0 / 255.0)
             XCTAssertEqual(rgb, expected)
         }
 
         do {
             let cmyk = CMYKColor(cyan: .zero, magenta: 0.28, yellow: 0.40, key: 0.54)
-            let rgb = cmyk.toRGB
+            let rgb = cmyk.sourceColor
             let expected = RGBColor(red: 117.0 / 255.0, green: 84.0 / 255.0, blue: 70.0 / 255.0)
             XCTAssertEqual(rgb, expected)
         }
@@ -161,28 +161,28 @@ final class ColorConverterTests: XCTestCase {
     func test_hsb_to_rgb() {
         do {
             let hsb = HSBColor(hue: .zero, saturation: .zero, brightness: .zero)
-            let rgb = hsb.toRGB
+            let rgb = hsb.sourceColor
             let expected = RGBColor(red: .zero, green: .zero, blue: .zero)
             XCTAssertEqual(rgb, expected)
         }
 
         do {
             let hsb = HSBColor(hue: .zero, saturation: .zero, brightness: 1.0)
-            let rgb = hsb.toRGB
+            let rgb = hsb.sourceColor
             let expected = RGBColor(red: 1.0, green: 1.0, blue: 1.0)
             XCTAssertEqual(rgb, expected)
         }
 
         do {
             let hsb = HSBColor(hue: 0.66, saturation: 0.47, brightness: 0.90)
-            let rgb = hsb.toRGB
+            let rgb = hsb.sourceColor
             let expected = RGBColor(red: 122.0 / 255.0, green: 126.0 / 255.0, blue: 230.0 / 255.0)
             XCTAssertEqual(rgb, expected)
         }
 
         do {
             let hsb = HSBColor(hue: 0.05, saturation: 0.40, brightness: 0.46)
-            let rgb = hsb.toRGB
+            let rgb = hsb.sourceColor
             let expected = RGBColor(red: 117.0 / 255.0, green: 84.0 / 255.0, blue: 70.0 / 255.0)
             XCTAssertEqual(rgb, expected)
         }


### PR DESCRIPTION
### Added

- Add a `ColorType` protocol that includes a source color.
  - All colors should conform to the `ColorType` protocol.
  - The `sourceColor` property of ColorType should conform to the ColorConvertible protocol.

### Checklist ✅

- [x] The code has been linted using the command `make lint`.
- [x] Unit tests have been written to ensure major functionality is not broken.
