### PR TITLE
Add a JSONFormatter initial module

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -21,6 +21,7 @@ let project = Project.app(
         .feature(.colorConverter),
         .feature(.caseConverter),
         .feature(.lineSorter),
+        .feature(.jsonFormatter),
         .external(.dependencies),
         .external(.oneWay),
     ]

--- a/Projects/Features/JSONFormatter/Example/Resources/Assets.xcassets/Contents.json
+++ b/Projects/Features/JSONFormatter/Example/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Features/JSONFormatter/Example/Sources/JSONFormatterExampleApp.swift
+++ b/Projects/Features/JSONFormatter/Example/Sources/JSONFormatterExampleApp.swift
@@ -1,0 +1,16 @@
+// The MIT License (MIT)
+//
+// https://github.com/DevYeom/Coral
+
+import SwiftUI
+
+@main
+struct JSONFormatterExampleApp: App {
+
+    var body: some Scene {
+        WindowGroup {
+            JSONFormatterExampleView()
+        }
+    }
+
+}

--- a/Projects/Features/JSONFormatter/Example/Sources/JSONFormatterExampleView.swift
+++ b/Projects/Features/JSONFormatter/Example/Sources/JSONFormatterExampleView.swift
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// https://github.com/DevYeom/Coral
+
+import JSONFormatter
+import SwiftUI
+
+struct JSONFormatterExampleView: View {
+
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundColor(.accentColor)
+            Text("Hello, world!")
+        }
+        .padding()
+        .onAppear {
+            JSONFormatter.hello()
+        }
+    }
+
+}
+
+struct JSONFormatterExampleView_Previews: PreviewProvider {
+
+    static var previews: some View {
+        JSONFormatterExampleView()
+    }
+
+}

--- a/Projects/Features/JSONFormatter/Interface/JSONFormatterType.swift
+++ b/Projects/Features/JSONFormatter/Interface/JSONFormatterType.swift
@@ -1,0 +1,11 @@
+// The MIT License (MIT)
+//
+// https://github.com/DevYeom/Coral
+
+import Foundation
+
+public protocol JSONFormatterType {
+
+    static func hello()
+
+}

--- a/Projects/Features/JSONFormatter/Project.swift
+++ b/Projects/Features/JSONFormatter/Project.swift
@@ -1,0 +1,19 @@
+// The MIT License (MIT)
+//
+// https://github.com/DevYeom/Coral
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.static(
+    name: "JSONFormatter",
+    packages: [],
+    baseSettings: [:],
+    dependencies: [
+        .common(.coralKit),
+        .common(.coralUI),
+        .external(.dependencies),
+        .external(.oneWay),
+    ],
+    includeExample: true
+)

--- a/Projects/Features/JSONFormatter/Resources/Assets.xcassets/Contents.json
+++ b/Projects/Features/JSONFormatter/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Features/JSONFormatter/Sources/JSONFormatter.swift
+++ b/Projects/Features/JSONFormatter/Sources/JSONFormatter.swift
@@ -1,0 +1,14 @@
+// The MIT License (MIT)
+//
+// https://github.com/DevYeom/Coral
+
+import Foundation
+import JSONFormatterInterface
+
+public struct JSONFormatter: JSONFormatterType {
+
+    public static func hello() {
+        print("Hello JSONFormatter")
+    }
+
+}

--- a/Projects/Features/JSONFormatter/Testing/Generated/Mocks.swift
+++ b/Projects/Features/JSONFormatter/Testing/Generated/Mocks.swift
@@ -1,0 +1,1 @@
+// ReplaceMe

--- a/Projects/Features/JSONFormatter/Testing/JSONFormatterMock.swift
+++ b/Projects/Features/JSONFormatter/Testing/JSONFormatterMock.swift
@@ -1,0 +1,14 @@
+// The MIT License (MIT)
+//
+// https://github.com/DevYeom/Coral
+
+import Foundation
+import JSONFormatterInterface
+
+public struct JSONFormatterMock: JSONFormatterType {
+
+    public static func hello() {
+        print("Hello JSONFormatterMock")
+    }
+
+}

--- a/Projects/Features/JSONFormatter/Tests/JSONFormatterTests.swift
+++ b/Projects/Features/JSONFormatter/Tests/JSONFormatterTests.swift
@@ -1,0 +1,17 @@
+// The MIT License (MIT)
+//
+// https://github.com/DevYeom/Coral
+
+import Foundation
+import JSONFormatter
+import JSONFormatterTesting
+import XCTest
+
+final class JSONFormatterTests: XCTestCase {
+
+    func test_example() {
+        JSONFormatterMock.hello()
+        XCTAssertEqual("JSONFormatter", "JSONFormatter")
+    }
+
+}

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency.swift
@@ -15,6 +15,7 @@ public extension TargetDependency {
         case colorConverter = "ColorConverter"
         case caseConverter = "CaseConverter"
         case lineSorter = "LineSorter"
+        case jsonFormatter = "JSONFormatter"
     }
 
     enum External: String {

--- a/Tuist/Templates/module/module.swift
+++ b/Tuist/Templates/module/module.swift
@@ -14,7 +14,7 @@ let template = Template(
         .file(path: "Projects/\(name)/Sources/\(name).swift", templatePath: "sources.stencil"),
         .file(path: "Projects/\(name)/Interface/\(name)Type.swift", templatePath: "interface.stencil"),
         .file(path: "Projects/\(name)/Testing/\(name)Mock.swift", templatePath: "testing.stencil"),
-        .string(path: "Projects/\(name)/Testing/Generated/Mocks.swift", contents: "ReplaceMe"), // for mockolo
+        .string(path: "Projects/\(name)/Testing/Generated/Mocks.swift", contents: "// ReplaceMe"), // for mockolo
         .file(path: "Projects/\(name)/Tests/\(name)Tests.swift", templatePath: "tests.stencil"),
         .file(path: "Projects/\(name)/Resources/Assets.xcassets/Contents.json", templatePath: "contents_json.stencil"),
         .file(path: "Projects/\(name)/Example/Sources/\(name)ExampleApp.swift", templatePath: "example_app.stencil"),


### PR DESCRIPTION
### Added

- Generate a JSONFormatter module by using the module template

### Checklist ✅

- [x] The code has been linted using the command `make lint`.
- [x] Unit tests have been written to ensure major functionality is not broken.
