### PR TITLE
Fix lint warnings

### DIFF
--- a/Projects/Common/CoralKit/Sources/Persistence.swift
+++ b/Projects/Common/CoralKit/Sources/Persistence.swift
@@ -30,21 +30,20 @@ struct PersistenceController {
     init(inMemory: Bool = false) {
         container = NSPersistentCloudKitContainer(name: "Coral")
         if inMemory {
-            container.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
+            container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
         }
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in
             if let error = error as NSError? {
                 // Replace this implementation with code to handle the error appropriately.
                 // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
 
-                /*
-                 Typical reasons for an error here include:
-                 * The parent directory does not exist, cannot be created, or disallows writing.
-                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
-                 * The device is out of space.
-                 * The store could not be migrated to the current model version.
-                 Check the error message to determine what the actual problem was.
-                 */
+                /// Typical reasons for an error here include:
+                /// * The parent directory does not exist, cannot be created, or disallows writing.
+                /// * The persistent store is not accessible, due to permissions or data protection when the /// device is locked.
+                /// * The device is out of space.
+                /// * The store could not be migrated to the current model version.
+                /// Check the error message to determine what the actual problem was.
+
                 fatalError("Unresolved error \(error), \(error.userInfo)")
             }
         })

--- a/Projects/Common/CoralUI/Sources/CopyButton.swift
+++ b/Projects/Common/CoralUI/Sources/CopyButton.swift
@@ -35,5 +35,5 @@ public struct CopyButton: View {
                 .foregroundColor(.white)
         }
     }
-    
+
 }

--- a/Projects/Common/CoralUI/Sources/TextEffectButtonStyle.swift
+++ b/Projects/Common/CoralUI/Sources/TextEffectButtonStyle.swift
@@ -5,7 +5,7 @@
 import SwiftUI
 
 public struct EffectButtonStyle<Content: View>: ButtonStyle {
-    
+
     let effectView: Content
     @State private var showsEffect: Bool = false
 

--- a/Projects/Features/LineSorter/Testing/Generated/Mocks.swift
+++ b/Projects/Features/LineSorter/Testing/Generated/Mocks.swift
@@ -12,7 +12,7 @@ public enum Mocks {
             import ABCD
             """
 
-        public static let alphabetically_ordered: String =
+        public static let alphabeticallyOrdered: String =
             """
             import ABCD
             import AppKit
@@ -22,7 +22,7 @@ public enum Mocks {
             import zyx
             """
 
-        public static let alphabetically_reversed: String =
+        public static let alphabeticallyReversed: String =
             """
             import zyx
             import OneWay
@@ -32,7 +32,7 @@ public enum Mocks {
             import ABCD
             """
 
-        public static let lenghtly_ordered: String =
+        public static let lenghtlyOrdered: String =
             """
             import zyx
             import ABCD
@@ -42,7 +42,7 @@ public enum Mocks {
             import Foundation
             """
 
-        public static let lenghtly_reversed: String =
+        public static let lenghtlyReversed: String =
             """
             import Foundation
             import CoralKit
@@ -66,7 +66,7 @@ public enum Mocks {
             Prefix-124
             """
 
-        public static let alphabetically_ordered: String =
+        public static let alphabeticallyOrdered: String =
             """
             Prefix-11111
             Prefix-123
@@ -76,7 +76,7 @@ public enum Mocks {
             Prefix-459595
             """
 
-        public static let alphabetically_reversed: String =
+        public static let alphabeticallyReversed: String =
             """
             Prefix-459595
             Prefix-235623
@@ -86,7 +86,7 @@ public enum Mocks {
             Prefix-11111
             """
 
-        public static let lenghtly_ordered: String =
+        public static let lenghtlyOrdered: String =
             """
             Prefix-123
             Prefix-124
@@ -96,7 +96,7 @@ public enum Mocks {
             Prefix-459595
             """
 
-        public static let lenghtly_reversed: String =
+        public static let lenghtlyReversed: String =
             """
             Prefix-459595
             Prefix-235623

--- a/Projects/Features/LineSorter/Tests/LineSorterWayTests.swift
+++ b/Projects/Features/LineSorter/Tests/LineSorterWayTests.swift
@@ -23,27 +23,27 @@ final class LineSorterWayTests: XCTestCase {
         way.send(.edit(input: Mocks.Import.input))
 
         XCTAssertEqual(way.state.input, Mocks.Import.input)
-        XCTAssertEqual(way.state.output, Mocks.Import.alphabetically_ordered)
+        XCTAssertEqual(way.state.output, Mocks.Import.alphabeticallyOrdered)
 
         way.send(.updateOrderType(type: .reversed))
 
         XCTAssertEqual(way.state.input, Mocks.Import.input)
-        XCTAssertEqual(way.state.output, Mocks.Import.alphabetically_reversed)
+        XCTAssertEqual(way.state.output, Mocks.Import.alphabeticallyReversed)
 
         way.send(.updateSortType(type: .length))
 
         XCTAssertEqual(way.state.input, Mocks.Import.input)
-        XCTAssertEqual(way.state.output, Mocks.Import.lenghtly_reversed)
+        XCTAssertEqual(way.state.output, Mocks.Import.lenghtlyReversed)
 
         way.send(.updateOrderType(type: .ordered))
 
         XCTAssertEqual(way.state.input, Mocks.Import.input)
-        XCTAssertEqual(way.state.output, Mocks.Import.lenghtly_ordered)
+        XCTAssertEqual(way.state.output, Mocks.Import.lenghtlyOrdered)
 
         way.send(.edit(input: Mocks.Number.input))
 
         XCTAssertEqual(way.state.input, Mocks.Number.input)
-        XCTAssertEqual(way.state.output, Mocks.Number.lenghtly_ordered)
+        XCTAssertEqual(way.state.output, Mocks.Number.lenghtlyOrdered)
     }
 
     func test_number_statements_convert() {
@@ -59,27 +59,27 @@ final class LineSorterWayTests: XCTestCase {
         way.send(.edit(input: Mocks.Number.input))
 
         XCTAssertEqual(way.state.input, Mocks.Number.input)
-        XCTAssertEqual(way.state.output, Mocks.Number.alphabetically_ordered)
+        XCTAssertEqual(way.state.output, Mocks.Number.alphabeticallyOrdered)
 
         way.send(.updateOrderType(type: .reversed))
 
         XCTAssertEqual(way.state.input, Mocks.Number.input)
-        XCTAssertEqual(way.state.output, Mocks.Number.alphabetically_reversed)
+        XCTAssertEqual(way.state.output, Mocks.Number.alphabeticallyReversed)
 
         way.send(.updateSortType(type: .length))
 
         XCTAssertEqual(way.state.input, Mocks.Number.input)
-        XCTAssertEqual(way.state.output, Mocks.Number.lenghtly_reversed)
+        XCTAssertEqual(way.state.output, Mocks.Number.lenghtlyReversed)
 
         way.send(.updateOrderType(type: .ordered))
 
         XCTAssertEqual(way.state.input, Mocks.Number.input)
-        XCTAssertEqual(way.state.output, Mocks.Number.lenghtly_ordered)
+        XCTAssertEqual(way.state.output, Mocks.Number.lenghtlyOrdered)
 
         way.send(.edit(input: Mocks.Import.input))
 
         XCTAssertEqual(way.state.input, Mocks.Import.input)
-        XCTAssertEqual(way.state.output, Mocks.Import.lenghtly_ordered)
+        XCTAssertEqual(way.state.output, Mocks.Import.lenghtlyOrdered)
     }
 
 }


### PR DESCRIPTION
### Added

### Changed

### Fixed

- lint warnings

### Checklist ✅

- [x] The code has been linted using the command `make lint`.
- [x] Unit tests have been written to ensure major functionality is not broken.
